### PR TITLE
Set code element font-family

### DIFF
--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -1,3 +1,6 @@
+code, pre, kbd, samp {
+  font-family: $code-font-family;
+}
 
 .PageNavigation {
   font-size: 20px;
@@ -27,7 +30,7 @@
 }
 
 .nextprevlink {
-  @include relative-font-size(1.25); 
-  flex: 1 1 0; 
-  width: 45%;  
+  @include relative-font-size(1.25);
+  flex: 1 1 0;
+  width: 45%;
 }


### PR DESCRIPTION
## Summary
- ensure inline code, code blocks, keyboard input, and sample elements share the theme's code font family
- rebuild the static site so the compiled CSS reflects the new rule

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68c962c7f0a8832d8fe8f907da4ec663