### PR TITLE
Standardize tags across polynomial feature series

### DIFF
--- a/_posts/2024-01-21-Bernstein.md
+++ b/_posts/2024-01-21-Bernstein.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  “Are polynomial features the root of all evil?"
-tags: [machine-learning, feature-engineering, polynomials, polynomial-regression]
+tags: ["machine learning", "feature engineering", polynomials, "polynomial regression"]
 description: There is a well-known myth in the machine learning community - high degree polynomials are bad for modeling. In this post we debunk this myth.
 comments: true
 series: "Polynomial features in machine learning"

--- a/_posts/2024-01-25-Bernstein-Basis.md
+++ b/_posts/2024-01-25-Bernstein-Basis.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  “Keeping the polynomial monster under control"
-tags: [machine-learning, feature-engineering, polynomials, polynomial-regression]
+tags: ["machine learning", "feature engineering", polynomials, "polynomial regression"]
 description: We explore the Bernstein basis in more depth, and learn how to use the coefficients to control the shape of the fit curve.
 comments: true
 series: "Polynomial features in machine learning"

--- a/_posts/2024-02-11-Bernstein-Sklearn.md
+++ b/_posts/2024-02-11-Bernstein-Sklearn.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  “SkLearning with Bernstein Polynomials"
-tags: [machine-learning, feature-engineering, polynomials, polynomial-regression, scikit-learn]
+tags: ["machine learning", "feature engineering", polynomials, "polynomial regression", scikit-learn]
 description: We implement an Scikit-Learn transformer to generate Bernstein polynomial features, and try it out on the adult income data-set.
 comments: true
 series: "Polynomial features in machine learning"

--- a/_posts/2024-05-13-Bernstein-Pairwise-Sklearn.md
+++ b/_posts/2024-05-13-Bernstein-Pairwise-Sklearn.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "SkLearning with Bernstein Polynomials - continued"
-tags: [machine-learning, feature-engineering, polynomials, polynomial-regression, scikit-learn]
+tags: ["machine learning", "feature engineering", polynomials, "polynomial regression", scikit-learn]
 description: We implement an Scikit-Learn transformer to generate polynomial feature interactions using the Bernstein and the Power basis, and compare the performance of Bernstein pairwise interactions to the power basis, and to the Scikit-Learn polynomial transformer that produces interactions of equivalent length.
 comments: true
 series: "Polynomial features in machine learning"

--- a/_posts/2024-05-19-BernsteinCalibration.md
+++ b/_posts/2024-05-19-BernsteinCalibration.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "A Bernstein SkLearn model calibrator"
-tags: [machine-learning, feature-engineering, polynomials, polynomial-regression, scikit-learn]
+tags: ["machine learning", "feature engineering", polynomials, "polynomial regression", scikit-learn]
 description: We demonstrate an important use-case for Bernstein basis regularization in model calibration. We briefly discuss the use-cases of a well-calibrated machine learned classification model, and develop a simple calibrator that improves upon the ones provided by Scikit-Learn using regularization of the Bernstein basis.
 comments: true
 series: "Polynomial features in machine learning"

--- a/_posts/2024-06-03-PolynomialBasesRegProps.md
+++ b/_posts/2024-06-03-PolynomialBasesRegProps.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Regularization properties of polynomial bases"
-tags: [machine-learning, feature-engineering, polynomials, polynomial-regression, scikit-learn]
+tags: ["machine learning", "feature engineering", polynomials, "polynomial regression", scikit-learn]
 description: We study various polynomial bases from the bias-variance perspective, and the derivative-control properties of the Bernstein basis. This concludes our series on polynomial regression.
 comments: true
 series: "Polynomial features in machine learning"

--- a/_posts/2025-03-27-Free-Poly.md
+++ b/_posts/2025-03-27-Free-Poly.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Let the polynomial monster free"
-tags: [polynomial,legendre,chebyshev,fourier,machine learning,artificial intelligence,ai]
+tags: [polynomial, legendre, chebyshev, fourier, "machine learning", "artificial intelligence", ai]
 description: Overparametrized polynomial regression
 comments: true
 image: assets/polyfit_challenging_trunc.png

--- a/_posts/2025-04-17-Polynomial-Pruning.md
+++ b/_posts/2025-04-17-Polynomial-Pruning.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Off with the polynomial's tail!"
-tags: [polynomial,legendre,fourier,machine learning,artificial intelligence,ai]
+tags: [polynomial, legendre, fourier, "machine learning", "artificial intelligence", ai]
 description: Overparametrized Legendre polynomial regression with scikit-learn, with a few surprising properties!
 comments: true
 image: assets/california_housing_pruned_polys.png

--- a/_posts/2025-08-19-Orthogonality.md
+++ b/_posts/2025-08-19-Orthogonality.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Paying attention to feature distribution alignment"
-tags: [polynomial,legendre,fourier,machine learning,artificial intelligence,ai,alignment,attention]
+tags: [polynomial, legendre, fourier, "machine learning", "artificial intelligence", ai, alignment, attention]
 description: We discuss the meaning of weighted-orthogonality of function bases in feature engineering, and the relationship between the weight function and the feature distribution.
 comments: true
 image: assets/orthogonality_test_pipeline.png


### PR DESCRIPTION
## Summary
- replace hyphenated tag slugs in the Bernstein polynomial series posts with quoted natural-language phrases
- extend the same natural-language tag formatting to the remaining polynomial feature series posts
- retain the scikit-learn brand tag where applicable so its hyphenated name remains intact

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68c9d5e483a4832d930218bc4af5c3a2