### PR TITLE
Revise tags in Spectrum posts for clarity

### DIFF
--- a/_posts/2025-12-16-Spectrum.md
+++ b/_posts/2025-12-16-Spectrum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Behold the power of the spectrum!"
-tags: ["machine learning", "deep learning", "regression", "spectrum", "eigenvalue"]
+tags: ["machine learning", "regression", "eigenvalue models", "spectral methods", "shape constraints", "monotonicity", "convex regression", "concave regression", "pytorch"]
 description: We begin the exploration of matrix eigenvalues as machine-learned models.
 comments: true
 image: assets/pow_spec_auction_illustration.png

--- a/_posts/2026-01-01-Spectrum-Props.md
+++ b/_posts/2026-01-01-Spectrum-Props.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Robustness, interpretability, and scaling of eigenvalue models"
-tags: ["machine learning", "deep learning", "adversarial robustness", "robustness", "scaling", "spectrum", "eigenvalue", "symmetric", "hermitian"]
+tags: ["machine learning", "eigenvalue models", "adversarial robustness", "interpretability", "spectral norm", "operator norm", "regularization"]
 description: We discuss mathematical properties that relate to the robustness and interpretability of eigenvalues as models, and demonstrate those by training on a tabular dataset. We obtain a family that improves with scaling, while remaining interpretable and robust.
 comments: true
 image: assets/pow_spec_props_norms_reg_15.png


### PR DESCRIPTION
Updated tags to include more specific terms related to eigenvalue models and spectral methods.