### PR TITLE
Improve YAML descriptions for 2024+ posts

### DIFF
--- a/_posts/2024-01-21-Bernstein.md
+++ b/_posts/2024-01-21-Bernstein.md
@@ -2,7 +2,7 @@
 layout: post
 title:  “Are polynomial features the root of all evil?"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "overfitting", "regularization", "Bernstein polynomials", "approximation theory"]
-description: There is a well-known myth in the machine learning community - high degree polynomials are bad for modeling. In this post we debunk this myth.
+description: "High-degree polynomial features aren’t inherently unstable: the power basis and unscaled inputs are. This post shows how regularization and Bernstein polynomials make polynomial regression behave."
 comments: true
 series: "Polynomial features in machine learning"
 image: /assets/polyfit_bern_100_reg5em4.png

--- a/_posts/2024-01-25-Bernstein-Basis.md
+++ b/_posts/2024-01-25-Bernstein-Basis.md
@@ -2,7 +2,7 @@
 layout: post
 title:  “Keeping the polynomial monster under control"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "Bernstein polynomials", "shape constraints", "monotonic regression", "convex optimization", "regularization", "calibration", "cvxpy"]
-description: We explore the Bernstein basis in more depth, and learn how to use the coefficients to control the shape of the fit curve.
+description: "Bernstein coefficients act as control points for polynomial regression. This post shows how monotone and convex shape constraints become simple coefficient constraints, with theory and code."
 comments: true
 series: "Polynomial features in machine learning"
 slug: Bernstein-Basis

--- a/_posts/2024-02-11-Bernstein-Sklearn.md
+++ b/_posts/2024-02-11-Bernstein-Sklearn.md
@@ -2,7 +2,7 @@
 layout: post
 title:  “SkLearning with Bernstein Polynomials"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "scikit-learn", "Bernstein polynomials", "hyperparameter optimization", "ridge regression", "feature scaling", "California housing dataset"]
-description: We implement an Scikit-Learn transformer to generate Bernstein polynomial features, and try it out on the adult income data-set.
+description: "Build a scikit-learn transformer for Bernstein polynomial features and drop it into standard pipelines. Includes scaling, ridge regression, and a full run on the California Housing dataset."
 comments: true
 series: "Polynomial features in machine learning"
 image: /assets/bernstein_pipeline_chart.png

--- a/_posts/2024-05-13-Bernstein-Pairwise-Sklearn.md
+++ b/_posts/2024-05-13-Bernstein-Pairwise-Sklearn.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "SkLearning with Bernstein Polynomials - continued"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "scikit-learn", "Bernstein polynomials", "feature interactions", "tensor products", "hyperparameter optimization", "ridge regression", "California housing dataset"]
-description: We implement an Scikit-Learn transformer to generate polynomial feature interactions using the Bernstein and the Power basis, and compare the performance of Bernstein pairwise interactions to the power basis, and to the Scikit-Learn polynomial transformer that produces interactions of equivalent length.
+description: "Add pairwise feature interactions via tensor-product polynomial bases (Bernstein or power) in scikit-learn. Compare against PolynomialFeatures on the California Housing regression task."
 comments: true
 series: "Polynomial features in machine learning"
 image: /assets/bernstein_tensor_product.png

--- a/_posts/2024-05-19-BernsteinCalibration.md
+++ b/_posts/2024-05-19-BernsteinCalibration.md
@@ -2,7 +2,7 @@
 layout: post
 title: "A Bernstein SkLearn model calibrator"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "scikit-learn", "Bernstein polynomials", "model calibration", "probability calibration", "monotonic regression", "shape constraints", "support vector machines", "regularization", "cvxpy", "isotonic regression"]
-description: We demonstrate an important use-case for Bernstein basis regularization in model calibration. We briefly discuss the use-cases of a well-calibrated machine learned classification model, and develop a simple calibrator that improves upon the ones provided by Scikit-Learn using regularization of the Bernstein basis.
+description: "Train a monotone probability calibrator with Bernstein polynomial regression and shape constraints. Compare against scikit-learn sigmoid and isotonic calibration on a diabetes SVM."
 comments: true
 series: "Polynomial features in machine learning"
 image: /assets/svm_calibration_isotonic_bern_func.png

--- a/_posts/2024-06-03-PolynomialBasesRegProps.md
+++ b/_posts/2024-06-03-PolynomialBasesRegProps.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Regularization properties of polynomial bases"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "scikit-learn", "Bernstein polynomials", "Chebyshev polynomials", "Legendre polynomials", "bias-variance tradeoff", "regularization", "approximation theory"]
-description: We study various polynomial bases from the bias-variance perspective, and the derivative-control properties of the Bernstein basis. This concludes our series on polynomial regression.
+description: "Why do some polynomial bases regularize better than others? A bias-variance and derivative-control tour of power, Chebyshev, Legendre, and Bernstein bases with code experiments."
 comments: true
 series: "Polynomial features in machine learning"
 image: /assets/assets/bases_bias_var_viz_0.1.png

--- a/_posts/2024-06-14-Untilting.md
+++ b/_posts/2024-06-14-Untilting.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Untilting the tilted loss"
 tags: [machine-learning, tilted-loss,sgd]
-description: We study a way to represent a tilted loss as an average of losses by lifting to a higher dimensional space, and employing regular SGD
+description: "Tilted loss (log-sum-exp aggregation) interpolates between average and worst-case risk, but is tricky for SGD. Derive an 'untilting' reformulation and test it in PyTorch."
 comments: true
 image: /assets/tilted_adam_comparison.png
 ---

--- a/_posts/2024-07-07-HadamardParameterization.md
+++ b/_posts/2024-07-07-HadamardParameterization.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Fun with sparsity in PyTorch via Hadamard product parametrization"
 tags: [pytorch,machine-learning,sparse,sgd,hadamard-parametrization,factorization-machine]
-description: We demonstrate how we can reduce model size by pruning un-needed neurons.
+description: "Get sparsity in PyTorch via Hadamard product parametrization: turn L1-style sparsity into simple L2 weight decay. Demos include logistic regression, group sparsity, and pruning-by-training."
 comments: true
 image: /assets/hadamard_linear_convergence_plot.png
 ---
@@ -706,4 +706,3 @@ I hope you had fun reading it as much as I had fun writing it, and see you in th
 [^8]: Belloni, Alexandre, and Victor Chernozhukov. "ℓ1-penalized quantile regression in high-dimensional sparse models." (2011): 82-130.
 [^9]: BELLONI, ALEXANDRE, and VICTOR CHERNOZHUKOV. "Least squares after model selection in high-dimensional sparse models." Bernoulli (2013): 521-547.
 [^10]: Meinshausen, Nicolai. "Relaxed lasso." Computational Statistics & Data Analysis 52.1 (2007): 374-393.
-

--- a/_posts/2024-08-31-BatchIter.md
+++ b/_posts/2024-08-31-BatchIter.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Mini-batching with in-memory datasets"
 tags: [pytorch,machine-learning,data-loader]
-description: We develop an efficient alternative to PyTorch built-in dataloader class for the case of in-memory datasets, and lightweight models.
+description: "PyTorch DataLoader can be a bottleneck when your dataset already lives in memory (especially on GPU). Benchmark the overhead and use faster minibatch iterators, including group shuffling."
 comments: true
 image: /assets/group_shuffling.png
 ---

--- a/_posts/2024-10-14-Shape-Restricted-Models.md
+++ b/_posts/2024-10-14-Shape-Restricted-Models.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Shape restricted function models"
 tags: [pytorch,machine-learning,monotonic-regression,bernstein,polynomial-regression]
-description: Fitting shape-restricted functions with ease using PyTorch.
+description: "Build shape-restricted models in PyTorch by predicting Bernstein polynomial coefficients: monotone and bounded functions of a chosen feature, with flexible dependence on the rest."
 comments: true
 series: "Shape restricted models"
 image: /assets/increasing_function_model.png
@@ -571,4 +571,3 @@ Now let's get back to the realm of Bernstein polynomials. What happens if we wan
 [^7]: Grigoriy Blekherman, Pablo A. Parrilo, and Rekha R. Thomas. _Semidefinite Optimization and Convex Algebraic Geometry_. SIAM (2012)
 
 [^8]: Carl De-Boor. _A practical guide to splines_. (1993)
-

--- a/_posts/2024-11-09-Shape-Restricted-Models-Polyhedral.md
+++ b/_posts/2024-11-09-Shape-Restricted-Models-Polyhedral.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Shape restricted function models via polyhedral cones"
 tags: [pytorch,machine-learning,monotonic-regression,bernstein,polynomial-regression,polyhedral-cone]
-description: Advanced shape restrictions, such as combinations of monotonicity and convexity / concavity using polyhedral cones
+description: "Enforce richer shape constraints (convexity/concavity and combinations with monotonicity) by constraining coefficient vectors to polyhedral cones. Implement a PyTorch cone layer and fit concave functions."
 comments: true
 series: "Shape restricted models"
 image: /assets/polyedral_cone_layer.png
@@ -968,4 +968,3 @@ That's it! I hope you learned something new about incorporating constraints into
 [^4]: McMullen, P. (1970). The maximum numbers of faces of a convex polytope. *Mathematika*, *17*(2), 179-184.
 [^5]: Avis, D., & Fukuda, K. (1996). Reverse search for enumeration. *Discrete applied mathematics*, *65*(1-3), 21-46.
 [^6]: Fukuda, K., & Prodon, A. (1995, July). Double description method revisited. In *Franco-Japanese and Franco-Chinese conference on combinatorics and computer science* (pp. 91-111). Berlin, Heidelberg: Springer Berlin Heidelberg.
-

--- a/_posts/2025-03-27-Free-Poly.md
+++ b/_posts/2025-03-27-Free-Poly.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Let the polynomial monster free"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "double descent", "overparameterization", "generalization", "Legendre polynomials", "Chebyshev polynomials", "Fourier features"]
-description: Overparametrized polynomial regression
+description: "Overparameterized polynomial regression can exhibit double descent: past the interpolation threshold, some bases memorize and still generalize. Experiments compare power, Legendre, Chebyshev, and Fourier features."
 comments: true
 image: assets/polyfit_challenging_trunc.png
 series: "Polynomial features in machine learning"

--- a/_posts/2025-04-17-Polynomial-Pruning.md
+++ b/_posts/2025-04-17-Polynomial-Pruning.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Off with the polynomial's tail!"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "Legendre polynomials", "double descent", "model pruning", "feature selection", "scikit-learn", "California housing dataset"]
-description: Overparametrized Legendre polynomial regression with scikit-learn, with a few surprising properties!
+description: "Legendre polynomial feature regression on California Housing shows double descent; a simple tail-pruning of high-degree coefficients yields smaller, competitive models. Implemented in scikit-learn."
 comments: true
 image: assets/california_housing_pruned_polys.png
 series: "Polynomial features in machine learning"

--- a/_posts/2025-08-19-Orthogonality.md
+++ b/_posts/2025-08-19-Orthogonality.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Paying attention to feature distribution alignment"
 tags: ["machine learning", "feature engineering", "polynomials", "polynomial regression", "Legendre polynomials", "orthogonal polynomials", "feature scaling", "quantile transformer", "correlation analysis", "California housing dataset"]
-description: We discuss the meaning of weighted-orthogonality of function bases in feature engineering, and the relationship between the weight function and the feature distribution.
+description: "Orthogonal polynomial features are only uncorrelated when the feature distribution matches the basis weight. Use CDF/quantile transforms to align distributions and get more informative Legendre features."
 comments: true
 image: assets/orthogonality_test_pipeline.png
 series: "Polynomial features in machine learning"

--- a/_posts/2025-12-16-Spectrum.md
+++ b/_posts/2025-12-16-Spectrum.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Behold the power of the spectrum!"
 tags: ["machine learning", "regression", "eigenvalue models", "spectral methods", "shape constraints", "monotonicity", "convex regression", "concave regression", "pytorch"]
-description: We begin the exploration of matrix eigenvalues as machine-learned models.
+description: "Eigenvalues as neurons: represent nonlinear models as the k-th eigenvalue of a learned symmetric matrix pencil. Explore monotonicity/convexity properties and train simple spectral models."
 comments: true
 image: assets/pow_spec_auction_illustration.png
 series: "Eigenvalues as models"

--- a/_posts/2026-01-01-Spectrum-Props.md
+++ b/_posts/2026-01-01-Spectrum-Props.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Robustness, interpretability, and scaling of eigenvalue models"
 tags: ["machine learning", "eigenvalue models", "adversarial robustness", "interpretability", "spectral norm", "operator norm", "regularization"]
-description: "Eigenvalue models for tabular ML: interpretable feature interactions with robustness guarantees. Theory + scaling experiments."
+description: "Robustness, interpretability, and scaling of eigenvalue models: stability bounds from Weyl's inequality, operator-norm feature importance, and regularization experiments for tabular data."
 comments: true
 image: assets/pow_spec_props_norms_reg_15.png
 series: "Eigenvalues as models"


### PR DESCRIPTION
Rewrite front matter descriptions to be more specific and SEO-friendly, and correct the Bernstein-Sklearn dataset mention.